### PR TITLE
jsdom dependency as a peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "@jest/fake-timers": "^24.3.0",
     "@jest/types": "^24.3.0",
     "jest-mock": "^24.0.0",
-    "jest-util": "^24.0.0",
-    "jsdom": "^15.1.0"
+    "jest-util": "^24.0.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.11",
@@ -33,6 +32,9 @@
     "rimraf": "^2.6.3",
     "ts-jest": "^24.0.0",
     "typescript": "~3.3.3333"
+  },
+  "peerDependencies": {
+    "jsdom": "^15.1.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
We ([@lwc/jest-preset](https://github.com/salesforce/lwc-test/tree/master/packages/%40lwc/jest-preset)) have a dependency on `jest-environment-jsdom-fifteen` and it's currently not possible for us to control the version of the indirect `jsdom` dependency for downstream projects when they utilize lock files because of [this issue](https://github.com/yarnpkg/yarn/issues/4986).

For example, we just made some contributions in `jsdom@15.2.0` but downstream projects using `yarn` need to uninstall and then install `@lwc/jest-preset` in order to get that upgrade because the version of `jsdom` is otherwise stuck at `15.1.0`.

This change allows projects with a dependency on `jest-environment-jsdom-fifteen` to control the `jsdom` version being used.